### PR TITLE
UI tweaks

### DIFF
--- a/addon/components/grouped-toc.js
+++ b/addon/components/grouped-toc.js
@@ -26,7 +26,9 @@ export default class GroupedTocComponent extends Component {
     result.sort((a, b) => a.stage.order - b.stage.order);
 
     // add links with no stage or an invalid stage after the sorted list
-    result.push(noStage);
+    if (noStage.links.lenght) {
+      result.push(noStage);
+    }
 
     return result;
   }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -38,3 +38,7 @@ button.reset {
 ul.chapter {
   margin-top: 0;
 }
+
+.rfc-data-table ul {
+  padding-left: 1em;
+}

--- a/addon/templates/rfc.hbs
+++ b/addon/templates/rfc.hbs
@@ -31,8 +31,16 @@
             {{/each-in}}
           </ul>
         </td>
-        <td><a href={{@model.proposalPr}}>RFC Proposal Link</a></td>
-        <td><a href={{@model.trackingLink}}>Tracking Link</a></td>
+        <td>
+          {{#if @model.proposalPr}}
+            <a href={{@model.proposalPr}}>RFC Proposal Link</a>
+          {{/if}}
+        </td>
+        <td>
+          {{#if @model.trackingLink}}
+            <a href={{@model.trackingLink}}>Tracking Link</a>
+          {{/if}}
+        </td>
         <td>{{@model.stage.name}}</td>
         <td><ul>
           {{#each @model.teams as |team|}}

--- a/addon/templates/rfc.hbs
+++ b/addon/templates/rfc.hbs
@@ -6,7 +6,7 @@
       </button>
     </div>
   </div>
-  <table>
+  <table class="rfc-data-table">
     <thead>
       <tr>
         <td>start Date</td>

--- a/addon/templates/rfc.hbs
+++ b/addon/templates/rfc.hbs
@@ -9,9 +9,9 @@
   <table class="rfc-data-table">
     <thead>
       <tr>
-        <td>start Date</td>
-        <td>release date</td>
-        <td>releaseVersions</td>
+        <td>Start Date</td>
+        <td>Release Date</td>
+        <td>Release Versions</td>
         <td>PR link</td>
         <td>Tracking Link</td>
         <td>Stage</td>


### PR DESCRIPTION
This just has a few UI tweaks that I noticed when looking at the deployed version https://ember-rfcs.netlify.app/

Each tweak is the title of each commit in this PR but I will list them here for ease: 

- fix excessive padding in lists on rfc headers
- only show rfc header links if they exist on the data
- only show [No Stage] group if there are any with no stage
- make rfc data headers use title case